### PR TITLE
enhance peak_value with gamutmax

### DIFF
--- a/src/psnr.jl
+++ b/src/psnr.jl
@@ -31,13 +31,10 @@ psnr(x, ref) = psnr(x, ref, peak_value(eltype(ref)))
 
 
 # implementation
-""" Define the default peakval for colors """
+""" Define the default peakval for colors, specialize gray and rgb to get scalar output"""
+peak_value(::Type{T}) where T <: Colorant = gamutmax(T)
 peak_value(::Type{T}) where T <: NumberLike = one(eltype(T))
 peak_value(::Type{T}) where T <: AbstractRGB = one(eltype(T))
-function peak_value(::Type{T}) where T <: Color3
-    err_msg = "peakval for PSNR can't be inferred and should be explicitly passed for $(T) images"
-    throw(ArgumentError(err_msg))
-end
 
 _psnr(x::GenericGrayImage, ref::GenericGrayImage, peakval::Real)::Real =
     20log10(peakval) - 10log10(mse(x, ref))

--- a/test/psnr.jl
+++ b/test/psnr.jl
@@ -82,15 +82,6 @@
             a = A .|> T
             b = B .|> T
 
-            # peakval of RGB is inferable
-            @test_nowarn psnr(a, B)
-            @test_throws ArgumentError psnr(A, b)
-
-            # generally, peakval is not inferable
-            @test_throws ArgumentError psnr(a, b)
-            @test_throws ArgumentError psnr(a, b, 1.0)
-            @test_throws ArgumentError psnr(a, b, [1.0])
-
             @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
             @test all(isinf.(psnr(A, A, [1.0, 1.0, 1.0])))
         end


### PR DESCRIPTION
this patch adds more inferable ability to different color types

Before patch:
`psnr(Lab.(img), Lab.(img))` would throw `ArgumentError` since `peakval` isn't defined for `Lab` images

After patch:
`psnr(Lab.(img), Lab.(img))` returns `[Inf, Inf, Inf]` since `peakval` is infered by `gamutmax`