### PR TITLE
`floattype` does not exist

### DIFF
--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -86,7 +86,7 @@ function _ssim_map(iqi::SSIM, x::GenericGrayImage, ref::GenericGrayImage, peakva
     C₁, C₂ = @. (peakval * K)^2
     C₃ = C₂/2
 
-    T = promote_type(floattype(eltype(ref)), floattype(eltype(x)))
+    T = float(promote_type(eltype(ref), eltype(x)))
     x = of_eltype(T, x)
     ref = of_eltype(T, ref)
 

--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -86,7 +86,7 @@ function _ssim_map(iqi::SSIM, x::GenericGrayImage, ref::GenericGrayImage, peakva
     C₁, C₂ = @. (peakval * K)^2
     C₃ = C₂/2
 
-    T = float(promote_type(eltype(ref), eltype(x)))
+    T = promote_type(float(eltype(ref)), float(eltype(x)))
     x = of_eltype(T, x)
     ref = of_eltype(T, ref)
 


### PR DESCRIPTION
in ssim.jl `T = promote_type(floattype(eltype(ref)), floattype(eltype(x)))`
changed to `  T = float(promote_type(eltype(ref), eltype(x)))`
which does what I think you want done, alternatively
in ssim.jl `T = promote_type(float(eltype(ref)), float(eltype(x)))`
