### PR TITLE
remove duplicated testset names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,11 +22,11 @@ OffsetArrays = ">= 0.10"
 julia = "1"
 
 [extras]
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["QuartzImageIO", "IterTools", "ReferenceTests", "Test", "TestImages"]
+test = ["ImageMagick", "IterTools", "ReferenceTests", "Test", "TestImages"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 # ImageQualityIndexes
 
+[![Build Status](https://travis-ci.org/JuliaImages/ImageQualityIndexes.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/ImageQualityIndexes.jl)
+[![Codecov](https://codecov.io/gh/JuliaImages/ImageQualityIndexes.jl/badge.svg?branch=master)](https://codecov.io/gh/JuliaImages/ImageQualityIndexes.jl)
+
 ImageQualityIndexes provides the basic image quality assessment methods.
 
 ## Supported indexes
 
-* `PSNR` -- Peak signal-to-noise ratio
-* `SSIM` -- Structural similarity
+### Full reference indexes
+
+* `PSNR`/`psnr` -- Peak signal-to-noise ratio
+* `SSIM`/`ssim` -- Structural similarity
 
 
 ## Basic usage
 
-In this package, each index corresponds to a `ImageQualityIndex` type, there are three ways to assess the image quality:
+The root type is `ImageQualityIndex`, each concrete index is supposed to be one of `FullReferenceIQI`, `ReducedReferenceIQI` and `NoReferenceIQI`.
+
+There are three ways to assess the image quality:
 
 * use the general protocol, e.g., `assess(PSNR(), x, ref)`. This reads as "**assess** the image quality of **x** using method **PSNR** with information **ref**"
 * each index instance is itself a function, e.g., `PSNR()(x, ref)`
-* for well-known indexes, there are also convenient name for it, e.g., `psnr(x, ref)`
+* for well-known indexes, there are also convenient name for it for benchmark purpose.
 
 For detailed usage of particular index, please check the docstring (e.g., `?PSNR`)
+
+## Examples
+
+```julia
+using Images, TestImages
+using ImageQualityIndexes
+
+img = testimage("lena_gray_256") .|> float64
+noisy_img = img .+ 0.1 .* randn(size(img))
+ssim(noisy_img, img) # 0.3577
+psnr(noisy_img, img) # 19.9941
+
+kernel = ones(3, 3)./9 # mean filter
+denoised_img = imfilter(noisy_img, kernel)
+ssim(denoised_img, img) # 0.6529
+psnr(denoised_img, img) # 26.0350
+```

--- a/test/psnr.jl
+++ b/test/psnr.jl
@@ -9,27 +9,25 @@
     A = [1.0 1.0 1.0; 1.0 1.0 1.0; 0.0 0.0 0.0]
     B = [1.0 1.0 1.0; 0.0 0.0 0.0; 1.0 1.0 1.0]
     for T in type_list
-        @testset "$T" begin
-            test_ndarray(iqi, sz_img_3, T)
+        test_ndarray(iqi, sz_img_3, T)
 
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            # scalar output
-            @test psnr(a, b) == assess(PSNR(), a, b)
-            @test psnr(a, b) == psnr(a, b, 1.0)
-            @test isinf(psnr(a, a))
+        # scalar output
+        @test psnr(a, b) == assess(PSNR(), a, b)
+        @test psnr(a, b) == psnr(a, b, 1.0)
+        @test isinf(psnr(a, a))
 
-            # vector output
-            @test size(psnr(a, b, [1.0])) == (1,)
-            @test mean(psnr(a, b, [1.0])) == psnr(a, b, 1.0)
-            @test all(isinf.(psnr(a, a, [1.0])))
+        # vector output
+        @test size(psnr(a, b, [1.0])) == (1,)
+        @test mean(psnr(a, b, [1.0])) == psnr(a, b, 1.0)
+        @test all(isinf.(psnr(a, a, [1.0])))
 
-            # FIXME: the result of Bool type is not strictly equal to others
-            eltype(T) <: Bool && continue
-            test_numeric(iqi, a, b, T)
-            test_numeric(iqi, channelview(a), channelview(b), T)
-        end
+        # FIXME: the result of Bool type is not strictly equal to others
+        eltype(T) <: Bool && continue
+        test_numeric(iqi, a, b, T)
+        test_numeric(iqi, channelview(a), channelview(b), T)
     end
     test_cross_type(iqi, A, B, type_list)
 
@@ -42,28 +40,26 @@
         RGB(0.0, 1.0, 0.0) RGB(1.0, 0.0, 0.0) RGB(1.0, 0.0, 1.0)
         RGB(0.0, 1.0, 1.0) RGB(1.0, 1.0, 0.0) RGB(0.0, 0.0, 0.0)]
     for T in type_list
-        @testset "$T" begin
-            test_ndarray(iqi, sz_img_3, T)
+        test_ndarray(iqi, sz_img_3, T)
 
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            # scalar output
-            @test psnr(a, b) == assess(PSNR(), a, b) == PSNR()(a, b)
-            @test psnr(a, b) == psnr(a, b, 1.0) == PSNR()(a, b, 1.0)
-            @test psnr(a, b) == psnr(channelview(a), channelview(b))
-            @test isinf(psnr(a, a))
+        # scalar output
+        @test psnr(a, b) == assess(PSNR(), a, b) == PSNR()(a, b)
+        @test psnr(a, b) == psnr(a, b, 1.0) == PSNR()(a, b, 1.0)
+        @test psnr(a, b) == psnr(channelview(a), channelview(b))
+        @test isinf(psnr(a, a))
 
-            # vector output
-            @test_throws ArgumentError psnr(a, b, [1.0])
-            @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
-            @test size(psnr(a, b, [1.0, 1.0, 1.0])) == (3,)
-            @test mean(psnr(a, b, [1.0, 1.0, 1.0])) != psnr(a, b) # generally they doesn't equal
-            @test all(isinf.(psnr(a, a, [1.0, 1.0, 1.0])))
+        # vector output
+        @test_throws ArgumentError psnr(a, b, [1.0])
+        @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
+        @test size(psnr(a, b, [1.0, 1.0, 1.0])) == (3,)
+        @test mean(psnr(a, b, [1.0, 1.0, 1.0])) != psnr(a, b) # generally they doesn't equal
+        @test all(isinf.(psnr(a, a, [1.0, 1.0, 1.0])))
 
-            test_numeric(iqi, a, b, T)
-            test_numeric(iqi, channelview(a), channelview(b), T; filename="references/PSNR_2d_RGB")
-        end
+        test_numeric(iqi, a, b, T)
+        test_numeric(iqi, channelview(a), channelview(b), T; filename="references/PSNR_2d_RGB")
     end
     type_list = generate_test_types([Float32, N0f8], [RGB, BGR])
     test_cross_type(iqi, A, B, type_list)
@@ -78,21 +74,19 @@
         RGB(0.0, 1.0, 0.0) RGB(1.0, 0.0, 0.0) RGB(1.0, 0.0, 1.0)
         RGB(0.0, 1.0, 1.0) RGB(1.0, 1.0, 0.0) RGB(0.0, 0.0, 0.0)]
     for T in type_list
-        @testset "$T" begin
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            # peakval of RGB is inferable
-            @test_nowarn psnr(a, B)
-            @test_throws ArgumentError psnr(A, b)
+        # peakval of RGB is inferable
+        @test_nowarn psnr(a, B)
+        @test_throws ArgumentError psnr(A, b)
 
-            # generally, peakval is not inferable
-            @test_throws ArgumentError psnr(a, b)
-            @test_throws ArgumentError psnr(a, b, 1.0)
-            @test_throws ArgumentError psnr(a, b, [1.0])
+        # generally, peakval is not inferable
+        @test_throws ArgumentError psnr(a, b)
+        @test_throws ArgumentError psnr(a, b, 1.0)
+        @test_throws ArgumentError psnr(a, b, [1.0])
 
-            @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
-            @test all(isinf.(psnr(A, A, [1.0, 1.0, 1.0])))
-        end
+        @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
+        @test all(isinf.(psnr(A, A, [1.0, 1.0, 1.0])))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using ImageQualityIndexes
-using Test, ReferenceTests, TestImages
+using Test, ReferenceTests, TestImages, ImageFiltering
 using Statistics
 
 include("testutils.jl")
 
-@testset "SSIM" begin
+@testset "ImageQualityIndexes" begin
 
     include("psnr.jl")
     include("ssim.jl")

--- a/test/ssim.jl
+++ b/test/ssim.jl
@@ -25,20 +25,18 @@ using ImageFiltering
     A = [1.0 1.0 1.0; 1.0 1.0 1.0; 0.0 0.0 0.0]
     B = [1.0 1.0 1.0; 0.0 0.0 0.0; 1.0 1.0 1.0]
     for T in type_list
-        @testset "$T" begin
-            test_ndarray(iqi, sz_img_3, T)
+        test_ndarray(iqi, sz_img_3, T)
 
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-            @test ssim(a, a) ≈ 1.0
+        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test ssim(a, a) ≈ 1.0
 
-            # FIXME: the result of Bool type is not strictly equal to others
-            eltype(T) <: Bool && continue
-            test_numeric(iqi, a, b, T)
-            test_numeric(iqi, channelview(a), channelview(b), T)
-        end
+        # FIXME: the result of Bool type is not strictly equal to others
+        eltype(T) <: Bool && continue
+        test_numeric(iqi, a, b, T)
+        test_numeric(iqi, channelview(a), channelview(b), T)
     end
     test_cross_type(iqi, A, B, type_list)
 
@@ -55,20 +53,18 @@ using ImageFiltering
         RGB(0.0, 1.0, 0.0) RGB(1.0, 0.0, 0.0) RGB(1.0, 0.0, 1.0)
         RGB(0.0, 1.0, 1.0) RGB(1.0, 1.0, 0.0) RGB(0.0, 0.0, 0.0)]
     for T in type_list
-        @testset "$T" begin
-            test_ndarray(iqi, sz_img_3, T)
+        test_ndarray(iqi, sz_img_3, T)
 
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-            @test ssim(a, b) == ssim(channelview(a), channelview(b))
-            @test ssim(a, a) ≈ 1.0
+        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test ssim(a, b) == ssim(channelview(a), channelview(b))
+        @test ssim(a, a) ≈ 1.0
 
-            # RGB is treated as 3d gray image
-            test_numeric(iqi, a, b, T)
-            test_numeric(iqi, channelview(a), channelview(b), T; filename="references/SSIM_2d_RGB")
-        end
+        # RGB is treated as 3d gray image
+        test_numeric(iqi, a, b, T)
+        test_numeric(iqi, channelview(a), channelview(b), T; filename="references/SSIM_2d_RGB")
     end
     type_list = generate_test_types([Float32, N0f8], [RGB, BGR])
     test_cross_type(iqi, A, B, type_list)
@@ -82,18 +78,16 @@ using ImageFiltering
         RGB(0.0, 1.0, 0.0) RGB(1.0, 0.0, 0.0) RGB(1.0, 0.0, 1.0)
         RGB(0.0, 1.0, 1.0) RGB(1.0, 1.0, 0.0) RGB(0.0, 0.0, 0.0)]
     for T in type_list
-        @testset "$T" begin
-            a = A .|> T
-            b = B .|> T
+        a = A .|> T
+        b = B .|> T
 
-            @test_nowarn ssim(A, b), ssim(a, B)
+        @test_nowarn ssim(A, b), ssim(a, B)
 
-            @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-            @test ssim(A, A) ≈ 1.0
+        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test ssim(A, A) ≈ 1.0
 
-            # conversion to RGB first differs from no conversion
-            @test ssim(a, b) ≠ ssim(channelview(a), channelview(b))
-        end
+        # conversion to RGB first differs from no conversion
+        @test ssim(a, b) ≠ ssim(channelview(a), channelview(b))
     end
     @test ssim(A, B) ≈ ssim(Lab.(A), B) atol=1e-4
 end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -35,12 +35,9 @@ function test_numeric(dist, a, b, T; filename=nothing)
             filename = filename * "_$(_base_colorant_type(T))"
         end
     end
-    @testset "numeric" begin
-        @testset "$T" begin
-            # @test_reference "$(filename)_$(eltype(a))_$(eltype(b)).txt" assess(dist, a, b)
-            @test_reference "$(filename).txt" Float64(assess(dist, a, b))
-        end
-    end
+
+    # @test_reference "$(filename)_$(eltype(a))_$(eltype(b)).txt" assess(dist, a, b)
+    @test_reference "$(filename).txt" Float64(assess(dist, a, b))
 end
 
 """


### PR DESCRIPTION
When we have two testsets of the same name, test failures would not be summarized. That said, CI would show a pass when it's actually a failure.