### PR TITLE
rename psnr and ssim to assess_psnr and assess_ssim

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageQualityIndexes"
 uuid = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ ImageQualityIndexes provides the basic image quality assessment methods. Check t
 
 ### Full reference indexes
 
-* `PSNR`/`psnr` -- Peak signal-to-noise ratio
-* `SSIM`/`ssim` -- Structural similarity
+* `PSNR`/`assess_psnr` -- Peak signal-to-noise ratio
+* `SSIM`/`assess_ssim` -- Structural similarity
 
 ### No-reference indexes
 
@@ -37,13 +37,13 @@ using ImageQualityIndexes
 
 img = testimage("lena_gray_256") .|> float64
 noisy_img = img .+ 0.1 .* randn(size(img))
-ssim(noisy_img, img) # 0.3577
-psnr(noisy_img, img) # 19.9941
+assess_ssim(noisy_img, img) # 0.3577
+assess_psnr(noisy_img, img) # 19.9941
 
 kernel = ones(3, 3)./9 # mean filter
 denoised_img = imfilter(noisy_img, kernel)
-ssim(denoised_img, img) # 0.6529
-psnr(denoised_img, img) # 26.0350
+assess_ssim(denoised_img, img) # 0.6529
+assess_psnr(denoised_img, img) # 26.0350
 
 img = testimage("lena_color_256");
 colorfulness(img) # 64.1495

--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -11,6 +11,7 @@ include("generic.jl")
 include("psnr.jl")
 include("ssim.jl")
 include("colorfulness.jl")
+include("deprecations.jl")
 
 export
     # generic
@@ -18,11 +19,11 @@ export
 
     # Peak signal-to-noise ratio
     PSNR,
-    psnr,
+    assess_psnr,
 
     # Structral Similarity
     SSIM,
-    ssim,
+    assess_ssim,
 
     # Colorfulness
     HASLER_AND_SUSSTRUNK_M3,

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,5 @@
+# renaming `psnr` and `ssim` following the general guideline
+# > for functions that compute something or perform an operation, start with a verb
+# https://github.com/JuliaImages/Images.jl/issues/767
+Base.@deprecate_binding psnr assess_psnr
+Base.@deprecate_binding ssim assess_ssim

--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -1,7 +1,7 @@
 """
     SSIM([kernel], [(α, β, γ)]) <: FullReferenceIQI
     assess(iqi::SSIM, img, ref)
-    ssim(img, ref)
+    assess_ssim(img, ref)
 
 Structural similarity (SSIM) index is an image quality assessment method based
 on degradation of structural information.
@@ -65,7 +65,7 @@ SSIM(kernel=SSIM_KERNEL) = SSIM(kernel, SSIM_W)
 (iqi::SSIM)(x, ref) = mean(_ssim_map(iqi, x, ref))
 
 @doc (@doc SSIM)
-ssim(x, ref) = SSIM()(x, ref)
+assess_ssim(x, ref) = SSIM()(x, ref)
 
 # Parameters `(K₁, K₂)` are used to avoid instability when denominator is very
 # close to zero. Different from origianl implementation [2], we don't make it

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,7 @@
+@testset "deprecations" begin
+    @info "depwarns are expected"
+    img1 = testimage("cameraman")
+    img2 = testimage("lena_gray_512")
+    @test ssim(img1, img2) == assess_ssim(img1, img2)
+    @test psnr(img1, img2) == assess_psnr(img1, img2)
+end

--- a/test/psnr.jl
+++ b/test/psnr.jl
@@ -15,14 +15,14 @@
         b = B .|> T
 
         # scalar output
-        @test psnr(a, b) == assess(PSNR(), a, b)
-        @test psnr(a, b) == psnr(a, b, 1.0)
-        @test isinf(psnr(a, a))
+        @test assess_psnr(a, b) == assess(PSNR(), a, b)
+        @test assess_psnr(a, b) == assess_psnr(a, b, 1.0)
+        @test isinf(assess_psnr(a, a))
 
         # vector output
-        @test size(psnr(a, b, [1.0])) == (1,)
-        @test mean(psnr(a, b, [1.0])) == psnr(a, b, 1.0)
-        @test all(isinf.(psnr(a, a, [1.0])))
+        @test size(assess_psnr(a, b, [1.0])) == (1,)
+        @test mean(assess_psnr(a, b, [1.0])) == assess_psnr(a, b, 1.0)
+        @test all(isinf.(assess_psnr(a, a, [1.0])))
 
         # FIXME: the result of Bool type is not strictly equal to others
         eltype(T) <: Bool && continue
@@ -46,24 +46,24 @@
         b = B .|> T
 
         # scalar output
-        @test psnr(a, b) == assess(PSNR(), a, b) == PSNR()(a, b)
-        @test psnr(a, b) == psnr(a, b, 1.0) == PSNR()(a, b, 1.0)
-        @test psnr(a, b) == psnr(channelview(a), channelview(b))
-        @test isinf(psnr(a, a))
+        @test assess_psnr(a, b) == assess(PSNR(), a, b) == PSNR()(a, b)
+        @test assess_psnr(a, b) == assess_psnr(a, b, 1.0) == PSNR()(a, b, 1.0)
+        @test assess_psnr(a, b) == assess_psnr(channelview(a), channelview(b))
+        @test isinf(assess_psnr(a, a))
 
         # vector output
-        @test_throws ArgumentError psnr(a, b, [1.0])
-        @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
-        @test size(psnr(a, b, [1.0, 1.0, 1.0])) == (3,)
-        @test mean(psnr(a, b, [1.0, 1.0, 1.0])) != psnr(a, b) # generally they doesn't equal
-        @test all(isinf.(psnr(a, a, [1.0, 1.0, 1.0])))
+        @test_throws ArgumentError assess_psnr(a, b, [1.0])
+        @test assess_psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
+        @test size(assess_psnr(a, b, [1.0, 1.0, 1.0])) == (3,)
+        @test mean(assess_psnr(a, b, [1.0, 1.0, 1.0])) != assess_psnr(a, b) # generally they doesn't equal
+        @test all(isinf.(assess_psnr(a, a, [1.0, 1.0, 1.0])))
 
         test_numeric(iqi, a, b, T)
         test_numeric(iqi, channelview(a), channelview(b), T; filename="references/PSNR_2d_RGB")
     end
     type_list = generate_test_types([Float32, N0f8], [RGB, BGR])
     test_cross_type(iqi, A, B, type_list)
-    @test isapprox(psnr(Lab.(A), B), psnr(A, B); rtol=1e-5)
+    @test isapprox(assess_psnr(Lab.(A), B), assess_psnr(A, B); rtol=1e-5)
 
     # general Color3 images that doesn't have peakval inferred
     type_list = generate_test_types([Float32], [Lab, HSV])
@@ -77,7 +77,7 @@
         a = A .|> T
         b = B .|> T
 
-        @test psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
-        @test all(isinf.(psnr(A, A, [1.0, 1.0, 1.0])))
+        @test assess_psnr(a, b, [1.0, 1.0, 1.0]) == assess(PSNR(), a, b, [1.0, 1.0, 1.0]) == PSNR()(a, b, [1.0, 1.0, 1.0])
+        @test all(isinf.(assess_psnr(A, A, [1.0, 1.0, 1.0])))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ include("testutils.jl")
     include("psnr.jl")
     include("ssim.jl")
     include("colorfulness.jl")
+    include("deprecations.jl")
     
 end
 

--- a/test/ssim.jl
+++ b/test/ssim.jl
@@ -15,7 +15,7 @@ using ImageFiltering
     # numerical test
     img1 = testimage("cameraman")
     img2 = testimage("lena_gray_512")
-    @test ssim(img1, img2) ≈ 0.3595 atol=1e-4 # MATLAB built-in ssim result
+    @test assess_ssim(img1, img2) ≈ 0.3595 atol=1e-4 # MATLAB built-in ssim result
     iqi_δ = SSIM(KernelFactors.gaussian(1.5, 11), (1.0+1e-5, 1.0, 1.0))
     @test assess(iqi_δ, img1, img2) ≈ assess(SSIM(), img1, img2) atol = 1e-4
 
@@ -30,8 +30,8 @@ using ImageFiltering
         a = A .|> T
         b = B .|> T
 
-        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-        @test ssim(a, a) ≈ 1.0
+        @test assess_ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test assess_ssim(a, a) ≈ 1.0
 
         # FIXME: the result of Bool type is not strictly equal to others
         eltype(T) <: Bool && continue
@@ -43,7 +43,7 @@ using ImageFiltering
     # RGB image
     img1 = testimage("mandril_color")
     img2 = testimage("lena_color_512")
-    @test ssim(img1, img2) ≈ 0.0664 atol=1e-4 # MATLAB built-in ssim result
+    @test assess_ssim(img1, img2) ≈ 0.0664 atol=1e-4 # MATLAB built-in assess_ssim result
 
     type_list = generate_test_types([Float32, N0f8], [RGB])
     A = [RGB(0.0, 0.0, 0.0) RGB(0.0, 1.0, 0.0) RGB(0.0, 1.0, 1.0)
@@ -58,9 +58,9 @@ using ImageFiltering
         a = A .|> T
         b = B .|> T
 
-        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-        @test ssim(a, b) == ssim(channelview(a), channelview(b))
-        @test ssim(a, a) ≈ 1.0
+        @test assess_ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test assess_ssim(a, b) == assess_ssim(channelview(a), channelview(b))
+        @test assess_ssim(a, a) ≈ 1.0
 
         # RGB is treated as 3d gray image
         test_numeric(iqi, a, b, T)
@@ -81,13 +81,13 @@ using ImageFiltering
         a = A .|> T
         b = B .|> T
 
-        @test_nowarn ssim(A, b), ssim(a, B)
+        @test_nowarn assess_ssim(A, b), assess_ssim(a, B)
 
-        @test ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
-        @test ssim(A, A) ≈ 1.0
+        @test assess_ssim(a, b) == assess(SSIM(), a, b) == SSIM()(a, b)
+        @test assess_ssim(A, A) ≈ 1.0
 
         # conversion to RGB first differs from no conversion
-        @test ssim(a, b) ≠ ssim(channelview(a), channelview(b))
+        @test assess_ssim(a, b) ≠ assess_ssim(channelview(a), channelview(b))
     end
-    @test ssim(A, B) ≈ ssim(Lab.(A), B) atol=1e-4
+    @test assess_ssim(A, B) ≈ assess_ssim(Lab.(A), B) atol=1e-4
 end


### PR DESCRIPTION
Rename `psnr` and `ssim` to `assess_psnr` and `assess_ssim` according to
the general guideline [1]:

> for functions that compute something or perform an operation, start with a verb

References:

[1] https://github.com/JuliaImages/Images.jl/issues/767
[2] scikit-images also use similar names: `compare_psnr` and `compare_ssim`