### PR TITLE
ssim: Handle negative structure values with small gamma

### DIFF
--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -111,6 +111,11 @@ function _ssim_map(iqi::SSIM, x::GenericGrayImage, ref::GenericGrayImage, peakva
         c = @. (2σx_σy + C₂)/(σx² + σy² + C₂) # equation (9) in [1]
         s = @. (σxy + C₃)/(σx_σy + C₃) # equation (10) in [1]
 
+        # ensure that negative numbers in s are not being raised to powers less
+        # than 1, non-standard implementation
+        if γ < 1.0
+            s = max.(s, zero(eltype(s)))
+        end
         ssim_map = @. l^α * c^β * s^γ # equation (12) in [1]
     end
     return ssim_map

--- a/test/ssim.jl
+++ b/test/ssim.jl
@@ -19,6 +19,10 @@ using ImageFiltering
     iqi_δ = SSIM(KernelFactors.gaussian(1.5, 11), (1.0+1e-5, 1.0, 1.0))
     @test assess(iqi_δ, img1, img2) ≈ assess(SSIM(), img1, img2) atol = 1e-4
 
+    # non-standard powers
+    iqi_γ = SSIM(KernelFactors.gaussian(1.5, 11), (0.5, 0.5, 0.5))
+    @test iqi_γ(img1, img2) ≈ 0.5261 atol=1e-4
+    # non standard parameters, result may differ from other implementations
 
     # Gray image
     type_list = generate_test_types([Bool, Float32, N0f8], [Gray])


### PR DESCRIPTION
This commit prevents the structure (s) values from becoming negative if gamma is less than 1 to prevent complex number results.
Not so sure if we should always do this, or only when gamma is less than 1. In case we do the former, one of the tests fails as the value differs slightly.
Fixes #16