### PR TITLE
[compat] require ImageCore 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "ImageQualityIndexes"
 uuid = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageDistances = "51556ac3-7006-55f5-8cb3-34580c88182d"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
@@ -12,8 +11,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorVectorSpace = "0.6, 0.7, 0.8, 0.9"
-ImageCore = "0.8.3"
+ImageCore = "0.9"
 ImageDistances = "0.2.4"
 ImageFiltering = "0.6.3"
 OffsetArrays = "0.11, 1"

--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -1,7 +1,7 @@
 module ImageQualityIndexes
 
 using OffsetArrays
-using ImageCore, ColorVectorSpace
+using ImageCore
 # Where possible we avoid a direct dependency to reduce the number of [compat] bounds
 using ImageCore.MappedArrays
 using ImageCore: NumberLike, Pixel, GenericImage, GenericGrayImage

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -20,11 +20,11 @@ end
 _base_colorant_type(::Type{<:Number}) = Gray
 _base_colorant_type(::Type{T}) where T<:Colorant = base_colorant_type(T)
 """
-    test_numeric(dist, a, b, T; filename=nothing)
+    test_numeric(dist, a, b, T; filename=nothing, atol=1e-5)
 
 simply test that `dist` works for 2d image as expected, more tests go to `Distances.jl`
 """
-function test_numeric(dist, a, b, T; filename=nothing)
+function test_numeric(dist, a, b, T; filename=nothing, atol=1e-5)
     size(a) == size(b) || error("a and b should be the same size")
     if filename == nothing
         filename = "references/$(typeof(dist))_$(ndims(a))d"
@@ -35,8 +35,7 @@ function test_numeric(dist, a, b, T; filename=nothing)
             filename = filename * "_$(_base_colorant_type(T))"
         end
     end
-    # @test_reference "$(filename)_$(eltype(a))_$(eltype(b)).txt" assess(dist, a, b)
-    @test_reference "$(filename).txt" string(Float64(assess(dist, a, b)))
+    @test_reference "$(filename).txt" Float64(assess(dist, a, b)) by=(x,y)->isapprox(x,y; atol=atol)
 end
 
 """


### PR DESCRIPTION
and remove ColorVectorSpace as a direct dependency

closes #33 

cc: @Octogonapus