### PR TITLE
Qualify use of `centered`

### DIFF
--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -5,7 +5,8 @@ using ImageCore
 # Where possible we avoid a direct dependency to reduce the number of [compat] bounds
 using ImageCore.MappedArrays
 using ImageCore: NumberLike, Pixel, GenericImage, GenericGrayImage
-using ImageDistances, ImageFiltering
+using ImageDistances
+import ImageFiltering: KernelFactors, kernelfactors, imfilter
 using Statistics: mean, std
 using Base.Iterators: repeated, flatten
 

--- a/src/msssim.jl
+++ b/src/msssim.jl
@@ -42,7 +42,7 @@ struct MSSSIM{A, N} <: FullReferenceIQI
         all(x-> x>=0, flatten(W)) || throw(ArgumentError("α, β, γ should be non-negative for all scales, instead it's $(W)"))
         sum(flatten(W)) == 0 && throw(ArgumentError("MS-SSIM must have at least one weight > 0"))
 
-        kernel = centered(kernel)
+        kernel = OffsetArrays.centered(kernel)
         if num_scales ≠ length(W)
             W ≠ MSSSIM_W && @warn "truncate MS-SSIM weights to scale $num_scales"
         end

--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -54,7 +54,7 @@ struct SSIM{A<:AbstractVector} <: FullReferenceIQI
         ndims(kernel) == 1 || throw(ArgumentError("only 1-d kernel is valid"))
         issymetric(kernel) || @warn "SSIM kernel is assumed to be symmetric"
         all(W .>= 0) || throw(ArgumentError("(α, β, γ) should be non-negative, instead it's $(W)"))
-        kernel = centered(kernel)
+        kernel = OffsetArrays.centered(kernel)
         new{typeof(kernel)}(kernel, W, crop)
     end
 end


### PR DESCRIPTION
`centered` is exported by both ImageFiltering and OffsetArrays. This causes issues, as both packages are using within, so the name is ambiguous. Fix by (1) explicitly calling OffsetArrays.centered (2) import rather than using ImageFiltering.

Assume this bug was introduced by OffsetArrays recently newly exporting `centered` (introduced here: https://github.com/JuliaArrays/OffsetArrays.jl/pull/242)

For clarity, the problem this PR fixes is this (in a fresh environment, install `Images` and `TestImages` and run the example in the ImageQualityIndexes readme):

```
]st
[916415d5] Images v0.24.1
[5e47fb64] TestImages v1.6.0

julia> img = testimage("cameraman") .|> float64
noisy_img = img .+ 0.1 .* randn(size(img))
assess_ssim(noisy_img, img) 

WARNING: both ImageFiltering and OffsetArrays export "centered"; uses of it in module ImageQualityIndexes must be qualified
ERROR: UndefVarError: centered not defined
Stacktrace:
 [1] SSIM(kernel::OffsetArrays.OffsetVector{Float64, Vector{Float64}}, W::Tuple{Float64, Float64, Float64}; crop::Bool)
   @ ImageQualityIndexes ~/.julia/packages/ImageQualityIndexes/XJPki/src/ssim.jl:57
 [2] assess_ssim(x::Matrix{Gray{Float64}}, ref::Matrix{Gray{Float64}}; crop::Bool)
   @ ImageQualityIndexes ~/.julia/packages/ImageQualityIndexes/XJPki/src/ssim.jl:76
 [3] assess_ssim(x::Matrix{Gray{Float64}}, ref::Matrix{Gray{Float64}})
   @ ImageQualityIndexes ~/.julia/packages/ImageQualityIndexes/XJPki/src/ssim.jl:76
 [4] top-level scope
   @ REPL[11]:1

```