### PR TITLE
GMSD index

### DIFF
--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -11,6 +11,7 @@ using Statistics: mean, std
 using Base.Iterators: repeated, flatten
 
 include("generic.jl")
+include("gmsd.jl")
 include("psnr.jl")
 include("ssim.jl")
 include("msssim.jl")
@@ -32,6 +33,9 @@ export
     # Multi Scale Structural Similarity
     MSSSIM,
     assess_msssim,
+    
+    # Gradient Magnitude Standard Deviation
+    gmsd,
 
     # Colorfulness
     HASLER_AND_SUSSTRUNK_M3,

--- a/src/gmsd.jl
+++ b/src/gmsd.jl
@@ -1,0 +1,21 @@
+"""
+   gmsd(org_img, pred_img, T = 170.0)
+
+Inspired by the official implementtation
+
+"""
+function gmsd(org_img, pred_img, T = 170.0)
+    gmsd_list = []
+    for i in [red, green, blue] 
+        grad1x, grad1y, gm1, orient1 = imedge(i.(org_img))
+        grad2x, grad2y, gm2, orient2 = imedge(i.(pred_img))
+
+        gms_numerator = 2.0 * gm1 * gm2 .+ T
+        gms_denominator = gm1 ^ 2 + gm2 ^ 2 .+ T
+
+        gm = gms_numerator ./ gms_denominator
+        gmsd = std(gm)
+        push!(gmsd_list, gmsd)
+    end 
+    return gmsd_list
+end


### PR DESCRIPTION
- [x] Add GMSD(gradient magnitude standard deviation) index to ImageQualityIndexes
- GMSD depends on gradient magnitude which Images.jl provides so what we want to do about that? add here?
- Fixes: half of https://github.com/JuliaImages/ImageQualityIndexes.jl/issues/25
