### PR TITLE
ImageQualityIndexes v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageQualityIndexes"
 uuid = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.2.5"
+version = "0.3.0"
 
 [deps]
 ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"


### PR DESCRIPTION
- [x] entropy (https://github.com/JuliaImages/Images.jl/pull/971#issuecomment-910271594)
- [x] remove deprecations for `psnr` and `ssim` (https://github.com/JuliaImages/Images.jl/pull/971#issuecomment-955782097)