### PR TITLE
delete `psnr` and `ssim`

### DIFF
--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -15,7 +15,6 @@ include("psnr.jl")
 include("ssim.jl")
 include("msssim.jl")
 include("colorfulness.jl")
-include("deprecations.jl")
 
 export
     # generic

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,5 +1,0 @@
-# renaming `psnr` and `ssim` following the general guideline
-# > for functions that compute something or perform an operation, start with a verb
-# https://github.com/JuliaImages/Images.jl/issues/767
-Base.@deprecate_binding psnr assess_psnr
-Base.@deprecate_binding ssim assess_ssim

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,7 +1,0 @@
-@testset "deprecations" begin
-    @info "depwarns are expected"
-    img1 = testimage("cameraman")
-    img2 = testimage("lena_gray_512")
-    @test ssim(img1, img2) == assess_ssim(img1, img2)
-    @test psnr(img1, img2) == assess_psnr(img1, img2)
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,7 @@ include("testutils.jl")
     include("ssim.jl")
     include("msssim.jl")
     include("colorfulness.jl")
-    include("deprecations.jl")
-    
+
 end
 
 nothing


### PR DESCRIPTION
These two symbols are deprecated about 1.5 years ago https://github.com/JuliaImages/ImageQualityIndexes.jl/pull/15 and I think it should be safe to remove.