### PR TITLE
Restore SSIM_KERNEL and SSIM_W

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageQualityIndexes"
 uuid = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"

--- a/src/msssim.jl
+++ b/src/msssim.jl
@@ -34,7 +34,7 @@ struct MSSSIM{A, N} <: FullReferenceIQI
     kernel::A
     W::NTuple{N, NTuple{3, Float64}}
 
-    function MSSSIM(kernel=nothing, W=MSSSIM_W; num_scales::Integer=length(W))
+    function MSSSIM(kernel=SSIM_KERNEL, W=MSSSIM_W; num_scales::Integer=length(W))
         kernel = isnothing(kernel) ? ImageFiltering.KernelFactors.gaussian(1.5, 11) : kernel
 
         ndims(kernel) == 1 || throw(ArgumentError("only 1-d kernel is valid"))

--- a/src/msssim.jl
+++ b/src/msssim.jl
@@ -35,8 +35,6 @@ struct MSSSIM{A, N} <: FullReferenceIQI
     W::NTuple{N, NTuple{3, Float64}}
 
     function MSSSIM(kernel=SSIM_KERNEL, W=MSSSIM_W; num_scales::Integer=length(W))
-        kernel = isnothing(kernel) ? ImageFiltering.KernelFactors.gaussian(1.5, 11) : kernel
-
         ndims(kernel) == 1 || throw(ArgumentError("only 1-d kernel is valid"))
         issymetric(kernel) || @warn "MSSSIM kernel is assumed to be symmetric"
         all(length.(W) .== 3) || throw(ArgumentError("(α, β, γ) required for all scales, instead it's $(W)"))

--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -50,10 +50,7 @@ struct SSIM{A<:AbstractVector} <: FullReferenceIQI
     kernel::A
     W::NTuple{3, Float64}
     crop::Bool
-    function SSIM(kernel::Union{Nothing,AbstractVector}=nothing, W::Union{Nothing,NTuple}=nothing; crop=false)
-        # default values from [1]
-        kernel = isnothing(kernel) ? SSIM_KERNEL : kernel
-        W = isnothing(W) ? SSIM_W : W # (α, β, γ)
+    function SSIM(kernel::AbstractVector=SSIM_KERNEL, W::NTuple=SSIM_W; crop=false)
         ndims(kernel) == 1 || throw(ArgumentError("only 1-d kernel is valid"))
         issymetric(kernel) || @warn "SSIM kernel is assumed to be symmetric"
         all(W .>= 0) || throw(ArgumentError("(α, β, γ) should be non-negative, instead it's $(W)"))
@@ -63,7 +60,19 @@ struct SSIM{A<:AbstractVector} <: FullReferenceIQI
 end
 
 # default values from [1]
-const SSIM_KERNEL = ImageFiltering.KernelFactors.gaussian(1.5, 11) # kernel
+# kernel generated from ImageFiltering.KernelFactors.gaussian(1.5, 11)
+# don't use ImageFiltering directly here because we lazy-import that dependency
+const SSIM_KERNEL = OffsetArray([0.00102838008447911,
+        0.007598758135239185,
+        0.03600077212843083,
+        0.10936068950970002,
+        0.2130055377112537,
+        0.26601172486179436,
+        0.2130055377112537,
+        0.10936068950970002,
+        0.03600077212843083,
+        0.007598758135239185,
+        0.00102838008447911,], -5:5)
 const SSIM_W = (1.0, 1.0, 1.0) # (α, β, γ)
 
 Base.:(==)(ia::SSIM, ib::SSIM) = ia.kernel == ib.kernel && ia.W == ib.W && ia.crop == ib.crop

--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -52,8 +52,8 @@ struct SSIM{A<:AbstractVector} <: FullReferenceIQI
     crop::Bool
     function SSIM(kernel::Union{Nothing,AbstractVector}=nothing, W::Union{Nothing,NTuple}=nothing; crop=false)
         # default values from [1]
-        kernel = isnothing(kernel) ? ImageFiltering.KernelFactors.gaussian(1.5, 11) : kernel
-        W = isnothing(W) ? (1.0, 1.0, 1.0) : W # (α, β, γ)
+        kernel = isnothing(kernel) ? SSIM_KERNEL : kernel
+        W = isnothing(W) ? SSIM_W : W # (α, β, γ)
         ndims(kernel) == 1 || throw(ArgumentError("only 1-d kernel is valid"))
         issymetric(kernel) || @warn "SSIM kernel is assumed to be symmetric"
         all(W .>= 0) || throw(ArgumentError("(α, β, γ) should be non-negative, instead it's $(W)"))
@@ -61,6 +61,10 @@ struct SSIM{A<:AbstractVector} <: FullReferenceIQI
         new{typeof(kernel)}(kernel, W, crop)
     end
 end
+
+# default values from [1]
+const SSIM_KERNEL = ImageFiltering.KernelFactors.gaussian(1.5, 11) # kernel
+const SSIM_W = (1.0, 1.0, 1.0) # (α, β, γ)
 
 Base.:(==)(ia::SSIM, ib::SSIM) = ia.kernel == ib.kernel && ia.W == ib.W && ia.crop == ib.crop
 

--- a/test/ssim.jl
+++ b/test/ssim.jl
@@ -3,6 +3,9 @@ using ImageFiltering
 @testset "SSIM" begin
     @info "test: SSIM"
 
+    # ensure the precomputed value for SSIM_KERNEL is correct
+    @test ImageQualityIndexes.SSIM_KERNEL == ImageQualityIndexes.ImageFiltering.KernelFactors.gaussian(1.5, 11)
+
     iqi_a = SSIM()
     iqi_b = SSIM(KernelFactors.gaussian(1.5, 11))
     iqi_c = SSIM(KernelFactors.gaussian(1.5, 11), (1.0, 1.0, 1.0))


### PR DESCRIPTION
This PR restores two globals, `SSIM_KERNEL` and `SSIM_W`, which were removed in v0.3.1.

Fixes #50.
