### PR TITLE
bugfix: fix ssim world age issue

### DIFF
--- a/src/ssim.jl
+++ b/src/ssim.jl
@@ -170,14 +170,15 @@ end
 function _ssim_statistics(x::GenericImage, ref::GenericImage, window; crop)
     # For RGB and other Color3 images, we don't slide the window at the color channel.
     # In other words, these characters will be calculated channelwisely
-    window = ImageFiltering.kernelfactors(Tuple(repeated(window, ndims(ref))))
 
-    region = map(window, axes(x)) do w, a
-        o = length(w) ÷ 2
+    region = map(axes(x)) do a
+        o = length(window) ÷ 2
         # Even if crop=true, it crops only when image is larger than window
-        length(a) > length(w) ? (first(a)+o:last(a)-o) : a
+        length(a) > length(window) ? (first(a)+o:last(a)-o) : a
     end
     R = crop ? CartesianIndices(region) : CartesianIndices(x)
+
+    window = ImageFiltering.kernelfactors(Tuple(repeated(window, ndims(ref))))
 
     # don't slide the window in the channel dimension
     μx = view(ImageFiltering.imfilter(x,   window, "symmetric"), R) # equation (14) in [1]

--- a/test/msssim.jl
+++ b/test/msssim.jl
@@ -1,5 +1,3 @@
-using ImageFiltering
-
 @testset "MS-SSIM" begin
     @info "test: MS-SSIM"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,17 @@
 using ImageQualityIndexes
-using Test, ReferenceTests, TestImages
+using Test
+using ImageCore
+
+# For lazily imported packages, world age issue might occur at first call, these tests must
+# be put first.
+include("world_age_issue.jl")
+
+using ReferenceTests, TestImages
 using Suppressor
 using Statistics
 using OffsetArrays
 using ImageTransformations
+using ImageFiltering
 
 include("testutils.jl")
 

--- a/test/world_age_issue.jl
+++ b/test/world_age_issue.jl
@@ -1,0 +1,15 @@
+@testset "world age issue" begin
+    img = rand(Gray, 64, 64)
+    @testset "ssim" begin
+        foo() = assess_ssim(img, img)
+        @test foo() == 1.0
+    end
+    @testset "psnr" begin
+        foo() = assess_psnr(img, img)
+        @test foo() == Inf
+    end
+    @testset "entropy" begin
+        foo() = entropy(img)
+        @test_nowarn foo()
+    end
+end


### PR DESCRIPTION
on master:

```julia
using ImageQualityIndexes
foo() = assess_ssim(rand(64, 64), rand(64, 64))
foo()
```

```julia
ERROR: MethodError: no method matching length(::ImageFiltering.KernelFactors.ReshapedOneD{Float64, 2, 0, OffsetArrays.OffsetVector{Float64, Vector{Float64}}})
The applicable method may be too new: running in world age 32409, while current world is 32421.
Closest candidates are:
  length(::ImageFiltering.KernelFactors.ReshapedOneD{T, N, Npre, V} where {T, N, Npre, V<:(AbstractVector)}) at ~/.julia/packages/ImageFiltering/cs86y/src/imfilter.jl:1558 (method too new to be called from this world context.)
  length(::Union{Base.KeySet, Base.ValueIterator}) at abstractdict.jl:58
  length(::Union{DataStructures.OrderedRobinDict, DataStructures.RobinDict}) at ~/.julia/packages/DataStructures/59MD0/src/ordered_robin_dict.jl:86 (method too new to be called from this world context.)
  ...
Stacktrace:
  [1] (::ImageQualityIndexes.var"#9#10")(w::ImageFiltering.KernelFactors.ReshapedOneD{Float64, 2, 0, OffsetArrays.OffsetVector{Float64, Vector{Float64}}}, a::Base.OneTo{Int64})
    @ ImageQualityIndexes ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:176
  [2] map(f::ImageQualityIndexes.var"#9#10", t::Tuple{ImageFiltering.KernelFactors.ReshapedOneD{Float64, 2, 0, OffsetArrays.OffsetVector{Float64, Vector{Float64}}}, ImageFiltering.KernelFactors.ReshapedOneD{Float64, 2, 1, OffsetArrays.OffsetVector{Float64, Vector{Float64}}}}, s::Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}})
    @ Base ./tuple.jl:247
  [3] _ssim_statistics(x::Matrix{Float64}, ref::Matrix{Float64}, window::OffsetArrays.OffsetVector{Float64, Vector{Float64}}; crop::Bool)
    @ ImageQualityIndexes ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:175
  [4] __ssim_map_fast(x::Matrix{Float64}, ref::Matrix{Float64}, window::OffsetArrays.OffsetVector{Float64, Vector{Float64}}, C₁::Float64, C₂::Float64; crop::Bool)
    @ ImageQualityIndexes ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:151
  [5] _ssim_map(iqi::SSIM{OffsetArrays.OffsetVector{Float64, Vector{Float64}}}, x::Matrix{Float64}, ref::Matrix{Float64}, peakval::Float64, K::Tuple{Float64, Float64})
    @ ImageQualityIndexes ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:122
  [6] _ssim_map
    @ ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:105 [inlined]
  [7] (::SSIM{OffsetArrays.OffsetVector{Float64, Vector{Float64}}})(x::Matrix{Float64}, ref::Matrix{Float64})
    @ ImageQualityIndexes ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:85
  [8] #assess_ssim#5
    @ ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:88 [inlined]
  [9] assess_ssim
    @ ~/Documents/Julia/ImageQualityIndexes.jl/src/ssim.jl:88 [inlined]
 [10] foo()
    @ Main ./REPL[2]:1
 [11] top-level scope
    @ REPL[3]:1
```

Will bump a new patch release for this ASAP