### PR TITLE
Use SnoopPrecompile for precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ ImageDistances = "51556ac3-7006-55f5-8cb3-34580c88182d"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -19,6 +20,7 @@ ImageDistances = "0.2.4"
 ImageFiltering = "0.6.3, 0.7"
 LazyModules = "0.3"
 OffsetArrays = "0.11, 1"
+SnoopPrecompile = "1"
 julia = "1"
 
 [extras]

--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -19,6 +19,8 @@ include("msssim.jl")
 include("colorfulness.jl")
 include("entropy.jl")
 
+include("precompile.jl")
+
 export
     # generic
     assess,

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,18 @@
+using SnoopPrecompile
+
+@precompile_setup begin
+    imgs_list = Any[
+        [rand(Gray{N0f8}, 32, 32) for _ in 1:2],
+        [rand(RGB{N0f8}, 32, 32) for _ in 1:2],
+        [rand(Gray{Float64}, 32, 32) for _ in 1:2],
+        [rand(RGB{Float64}, 32, 32) for _ in 1:2],
+        [rand(N0f8, 32, 32) for _ in 1:2],
+        [rand(Float64, 32, 32) for _ in 1:2],
+    ]
+    @precompile_all_calls begin
+        for imgs in imgs_list
+            assess_psnr(imgs...)
+            assess_ssim(imgs...)
+        end
+    end
+end


### PR DESCRIPTION
In the spirit of https://github.com/JuliaImages/ImageFiltering.jl/pull/255 (dev-ed that branch as well since SSIM requires ImageFiltering.jl)

TTFX tested with julia-1.9 with pkgimage

| code | master | PR |
| --- | --- | --- |
| `assess_psnr(rand(RGB, 64, 64), rand(RGB, 64, 64))` | 2.076582 seconds | 0.008024 seconds |
| `assess_ssim(rand(RGB, 64, 64), rand(RGB, 64, 64))` | 1.637438 seconds | 0.016530 seconds |

@timholy I assume this is all we need? This is incredible!