### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ ImageDistances = "51556ac3-7006-55f5-8cb3-34580c88182d"
 ImageFiltering = "6a3955dd-da59-5b1f-98d4-e7296123deb5"
 LazyModules = "8cdb02fc-e678-4876-92c5-9defec4f444e"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -20,7 +20,7 @@ ImageDistances = "0.2.4"
 ImageFiltering = "0.6.3, 0.7"
 LazyModules = "0.3"
 OffsetArrays = "0.11, 1"
-SnoopPrecompile = "1"
+PrecompileTools = "1"
 julia = "1"
 
 [extras]

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,6 @@
-using SnoopPrecompile
+using PrecompileTools
 
-@precompile_setup begin
+@setup_workload begin
     imgs_list = Any[
         [rand(Gray{N0f8}, 32, 32) for _ in 1:2],
         [rand(RGB{N0f8}, 32, 32) for _ in 1:2],
@@ -9,7 +9,7 @@ using SnoopPrecompile
         [rand(N0f8, 32, 32) for _ in 1:2],
         [rand(Float64, 32, 32) for _ in 1:2],
     ]
-    @precompile_all_calls begin
+    @compile_workload begin
         for imgs in imgs_list
             assess_psnr(imgs...)
             assess_ssim(imgs...)


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
