### PR TITLE
only enable precompilation in Julia >= 1.9

### DIFF
--- a/src/ImageQualityIndexes.jl
+++ b/src/ImageQualityIndexes.jl
@@ -19,7 +19,11 @@ include("msssim.jl")
 include("colorfulness.jl")
 include("entropy.jl")
 
-include("precompile.jl")
+if VERSION >= v"1.9.0"
+    # It seems to be brittle to use `precompile` for old Julia versions (e.g., 1.7.3)
+    # Since this only makes a huge difference after Julia 1.9, we only enable it for recent versions.
+    include("precompile.jl")
+end
 
 export
     # generic


### PR DESCRIPTION
This isn't fully reproducible, but I feel it's because the precompilation workload is too heavy/brittle for old Julia in Windows.
So, I inserted a version check only for the new Julia versions.

```julia
julia> using ImageQualityIndexes
[ Info: Precompiling ImageQualityIndexes [2996bd0c-7a13-11e9-2da2-2f5ce47296a9]
ERROR: Failed to precompile ImageQualityIndexes [2996bd0c-7a13-11e9-2da2-2f5ce47296a9] to C:\Users\jc\.julia\compiled\v1.7\ImageQualityIndexes\jl_eQualityIndexes\jl_DB2D.tmp.
Stacktrace:
 [1] error(s::String)
   @ Base .\error.jl:33
 [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, ignore_loaded_modules::Bool)        
   @ Base .\loading.jl:1466
 [3] compilecache(pkg::Base.PkgId, path::String)
   @ Base .\loading.jl:1410
 [4] _require(pkg::Base.PkgId)
   @ Base .\loading.jl:1120
 [5] require(uuidkey::Base.PkgId)
   @ Base .\loading.jl:1013
 [6] require(into::Module, mod::Symbol)
   @ Base .\loading.jl:997

julia> using ImageQualityIndexes

```